### PR TITLE
Change package for visualizing indents

### DIFF
--- a/lua/spacefozzy/packer.lua
+++ b/lua/spacefozzy/packer.lua
@@ -30,7 +30,7 @@ return require('packer').startup(function(use)
 
   use 'psliwka/vim-smoothie'
 
-  use 'vim-scripts/indentLine.vim'
+  use "lukas-reineke/indent-blankline.nvim"
 
   use 'github/copilot.vim'
 


### PR DESCRIPTION
I was having trouble with the last indent visualization plugin because it fiddled with Vim's conceal. I'm loving https://github.com/lukas-reineke/indent-blankline.nvim and it doesn't have the same issue . This PR switches over to it :tada: 